### PR TITLE
Render shapes in finer (1x1) resolution

### DIFF
--- a/src/main/scala/com.socrata.tileserver/util/GeoProvider.scala
+++ b/src/main/scala/com.socrata.tileserver/util/GeoProvider.scala
@@ -55,8 +55,8 @@ object GeoProvider {
     // Returning a single instance of a shape (eg. simplify(min(info.geoColumn))
     // currently causes holes in large complex polygon datasets, so we're just
     // selecting the groupBy value for now.
-    val selectSimplified  = s"snap_to_grid(${info.geoColumn}, ${info.tile.resolution * 2})"
-    val groupBy = s"snap_to_grid(${info.geoColumn}, ${info.tile.resolution * 2})"
+    val selectSimplified  = s"snap_to_grid(${info.geoColumn}, ${info.tile.resolution})"
+    val groupBy = s"snap_to_grid(${info.geoColumn}, ${info.tile.resolution})"
 
     val selectKey = s"$$select"
     val whereKey = s"$$where"


### PR DESCRIPTION
See corresponding frontend PR to render more shapes at once. If this kills perf significantly we'll roll it back, but it's worth testing in staging.