### PR TITLE
Use 1x1 gridding/group-by instead of 2x2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 tests.log
 target
 .idea/
+.idea_modules/
 docker/tileserver-assembly.jar

--- a/src/test/scala/com.socrata.tileserver/util/GeoProviderTest.scala
+++ b/src/test/scala/com.socrata.tileserver/util/GeoProviderTest.scala
@@ -83,7 +83,7 @@ class GeoProviderTest extends TestBase with UnusedSugar with MockitoSugar {
       val nParams = GeoProvider.augmentParams(reqInfo(neither ++ mondara,
                                                       geoColumn=selectValue),
                                               whereValue)
-      nParams must have size (4)
+      nParams must have size (5)
       nParams(selectKey) must include (selectValue)
       nParams(selectKey) must include ("snap_to_grid")
       nParams(whereKey) must equal (whereValue)
@@ -101,7 +101,7 @@ class GeoProviderTest extends TestBase with UnusedSugar with MockitoSugar {
       val sParams = GeoProvider.augmentParams(reqInfo(neither ++ select ++ mondara,
                                                       geoColumn=selectValue),
                                               whereValue)
-      sParams must have size (4)
+      sParams must have size (5)
       sParams(selectKey) must startWith (s"$selectBase,")
       sParams(selectKey) must include (selectValue)
       sParams(selectKey) must include ("snap_to_grid")
@@ -114,7 +114,7 @@ class GeoProviderTest extends TestBase with UnusedSugar with MockitoSugar {
       val wParams = GeoProvider.augmentParams(reqInfo(neither ++ where ++ mondara,
                                                       geoColumn=selectValue),
                                               whereValue)
-      wParams must have size (4)
+      wParams must have size (5)
       wParams(otherKey) must equal (otherValue)
 
       wParams(selectKey) must include (selectValue)
@@ -128,7 +128,7 @@ class GeoProviderTest extends TestBase with UnusedSugar with MockitoSugar {
       val gParams = GeoProvider.augmentParams(reqInfo(neither ++ group ++ mondara,
                                                       geoColumn=selectValue),
                                               whereValue)
-      gParams must have size (4)
+      gParams must have size (5)
       gParams(otherKey) must equal (otherValue)
 
       gParams(selectKey) must include (selectValue)
@@ -141,7 +141,7 @@ class GeoProviderTest extends TestBase with UnusedSugar with MockitoSugar {
         reqInfo(neither ++ where ++ select ++ group ++ mondara, geoColumn=selectValue),
         whereValue)
 
-      allParams must have size (4)
+      allParams must have size (5)
       allParams(otherKey) must equal (otherValue)
 
       allParams(selectKey) must startWith (s"$selectBase,")


### PR DESCRIPTION
This helps get rid of the jagged edge issue, without *too* much of a performance hit as far as I can tell in staging. I'll do more testing in production once it gets there, before we start migrating existing customer datasets.

The temporary `$limit` override is so that we (a) don't have to closely coordinate the tileserver and frontend deployments or (b) be dependent on a frontend production deployment to continue testing this. More detail on (a) : if we deploy the tileserver 1x1 change but still cap the shapes returned at 50k, quite a few datasets end up with holes.