### PR TITLE
EN-5672: add a timeout parameter in soql query

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -20,6 +20,9 @@ com.socrata {
     }
   }
 
+  #query config
+  query-timeout = 5
+
   # Zookeeper config.
   curator {
     service-base-path = "/services"

--- a/src/main/scala/com.socrata.tileserver/config/TileServerConfig.scala
+++ b/src/main/scala/com.socrata.tileserver/config/TileServerConfig.scala
@@ -19,6 +19,9 @@ object TileServerConfig {
   lazy val renderHost = config.getString("tileserver.render-host")
   lazy val renderPort = config.getInt("tileserver.render-port")
 
+  /**Query configuration. */
+  lazy val queryTimeout = config.getString("query-timeout")
+
   /** Zookeeper configuration. */
   lazy val broker = new DiscoveryBrokerConfig(config, "curator")
 

--- a/src/main/scala/com.socrata.tileserver/util/GeoProvider.scala
+++ b/src/main/scala/com.socrata.tileserver/util/GeoProvider.scala
@@ -25,6 +25,8 @@ case class GeoProvider(client: CuratedServiceClient) {
   def doQuery(info: RequestInfo): GeoResponse = {
     val intersects = filter(info.tile, info.geoColumn, info.overscan.getOrElse(0))
     val params = augmentParams(info, intersects)
+    val paramsWithTimeout = addQueryTimeout(params,  config.TileServerConfig.queryTimeout)
+
     val headers = HeaderFilter.headers(info.req)
 
     val jsonReq = { base: RequestBuilder =>
@@ -33,7 +35,7 @@ case class GeoProvider(client: CuratedServiceClient) {
         addHeaders(headers).
         addHeader("X-Socrata-Federation" -> "Honey Badger").
         addHeader(ReqIdHeader -> info.requestId).
-        query(params).get
+        query(paramsWithTimeout).get
       logger.info(URLDecoder.decode(req.toString, UTF_8.name))
       req
     }
@@ -62,6 +64,7 @@ object GeoProvider {
   private val groupKey = '$' + "group"
   private val styleKey = '$' + "style"
   private val overscanKey = '$' + "overscan"
+  private val queryTimeoutKey = "$$" + "query_timeout_seconds"
 
   /** Adds `where` and `select` to the parameters in `req`.
     *
@@ -129,5 +132,10 @@ object GeoProvider {
   def filter(tile: QuadTile, geoColumn: String, overscan: Int): String = {
     val corners = tile.corners(overscan).map { case (lat, lon) => s"$lat $lon" }.mkString(",")
     s"intersects($geoColumn, 'MULTIPOLYGON((($corners)))')"
+  }
+
+  def addQueryTimeout(params: Map[String, String], queryTimeout: String): Map[String, String] = {
+    val queryTimeoutParam = queryTimeoutKey -> queryTimeout
+    params + queryTimeoutParam
   }
 }


### PR DESCRIPTION
core provides the option of passing a query_timeout_seconds parameter that is used deeper in the stack. This PR adds this parameter on Tileserver requests.