### PR TITLE
Drop query timeout to 1m and make configurable.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ ENV MAX_META_SIZE 128m
 # Threads currently use about 100m each.
 ENV MIN_THREADS 3
 ENV MAX_THREADS 5               
+ENV QUERY_TIMEOUT 1m
 ENV JMX_PORT 2049
 EXPOSE 2049
 

--- a/docker/tileserver.conf.j2
+++ b/docker/tileserver.conf.j2
@@ -9,6 +9,7 @@ com.socrata {
       min-threads = {{ MIN_THREADS }}
       max-threads = {{ MAX_THREADS }}
     }
+    query-timeout = {{ QUERY_TIMEOUT }}
   }
   common-zk-ensemble = {{ ZOOKEEPER_ENSEMBLE }}
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -20,7 +20,7 @@ com.socrata {
     }
 
     # query config
-    query-timeout = 5m
+    query-timeout = 1m
   }
 
   # Zookeeper config.


### PR DESCRIPTION
Recent versions of postgis appear to have de-optimized some of the
queries we make (or something, don't have full root cause yet).  In
practice we are already dropping requests above this layer in the
routing after 60 seconds, so give ourselves a little more protection
against overloading the backend.