### PR TITLE
Fix build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,14 @@ val TestOptionFullTraces = "-oDF"
 
 testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, TestOptionNoTraces)
 
+assemblyMergeStrategy in assembly := {
+  case PathList("module-info.class") =>
+    MergeStrategy.discard
+  case other =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(other)
+}
+
 enablePlugins(sbtbuildinfo.BuildInfoPlugin)
 // Setup revolver.
 Revolver.settings


### PR DESCRIPTION
Jackson now includes module info for JDK9+; eliminate it so assembly
is happy.