### PR TITLE
Forward "X-Forwarded-*" headers.

### DIFF
--- a/src/main/scala/com.socrata.tileserver/util/HeaderFilter.scala
+++ b/src/main/scala/com.socrata.tileserver/util/HeaderFilter.scala
@@ -8,7 +8,15 @@ import com.socrata.http.server.{HttpRequest, HttpResponse}
 /** Removes all headers that aren't known to be safe to duplicate. */
 object HeaderFilter {
   private val inHeaders =
-    Set("Authorization", "Cookie", "If-Modified-Since", "X-App-Token").map(_.toLowerCase)
+    Set(
+      "Authorization",
+      "Cookie",
+      "If-Modified-Since",
+      "X-App-Token",
+      "X-Forwarded-For",
+      "X-Forwarded-Proto"
+    ).map(_.toLowerCase)
+
   private val outHeaders =
     Set("Cache-Control", "Expires", "Last-Modified").map(_.toLowerCase)
 


### PR DESCRIPTION
Because the code forwards all X-Socrata-* headers, it will cause requests to be
rejected upstream now that we set "X-Socrata-Not-Local" on external requests
unless it also has "X-Forwarded-Proto" to indicate it is made over SSL.

The alternative would be to not blindly forward all "X-Socrata-*"
headers but this seems more in line with the code's somewhat
complicated desire to act in a proxy-ish manner and will give us
the original IP for logs.