### PR TITLE
Switch to `sbtWrapper`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,21 @@
-@Library('socrata-pipeline-library@3.0.0') _
+@Library('socrata-pipeline-library@7.0.0') _
 
 commonPipeline(
     defaultBuildWorker: 'build-worker',
     jobName: 'tileserver',
     language: 'scala',
-    languageVersion: '2.12',
+    languageOptions: [
+        crossCompile: true,
+    ],
     projects: [
         [
             name: 'tileserver',
             deploymentEcosystem: 'marathon-mesos',
             type: 'service',
+            compiled: true,
+            paths: [
+                dockerBuildContext: 'docker'
+            ]
         ]
     ],
     teamsChannelWebhookId: 'WORKFLOW_IQ',

--- a/build.sbt
+++ b/build.sbt
@@ -56,3 +56,5 @@ enablePlugins(BuildInfoPlugin)
 buildInfoOptions := Seq(
   BuildInfoOption.BuildTime,
 )
+
+assembly/assemblyJarName := s"${name.value}-assembly.jar"


### PR DESCRIPTION
This commit transitions this repository's Jenkins job to use sbtWrapper, a replacement for the legacy sbtWrapper. sbtWrapper induces backwards incompatible changes in the common pipeline, and the major version of pipelines is accordingly bumped.